### PR TITLE
Normalize hardware response keys across APIs

### DIFF
--- a/BudSimulator/src/api/hardware_routes.py
+++ b/BudSimulator/src/api/hardware_routes.py
@@ -2,6 +2,7 @@
 from flask import request, jsonify
 from BudSimulator.src.hardware import BudHardware
 from BudSimulator.src.hardware_recommendation import HardwareRecommendation
+from BudSimulator.src.utils.hardware_formatting import normalize_hardware_keys
 
 
 def create_hardware_routes(app):
@@ -66,10 +67,12 @@ def create_hardware_routes(app):
             
             results = hardware.search_hardware(**params)
             
+            normalized_results = [normalize_hardware_keys(hw) for hw in results]
+
             return jsonify({
                 'success': True,
-                'hardware': results,
-                'count': len(results)
+                'hardware': normalized_results,
+                'count': len(normalized_results)
             }), 200
             
         except Exception as e:

--- a/BudSimulator/src/utils/hardware_formatting.py
+++ b/BudSimulator/src/utils/hardware_formatting.py
@@ -1,0 +1,22 @@
+"""Utility helpers for formatting hardware payloads."""
+from typing import Any, Dict
+
+
+def normalize_hardware_keys(hardware: Dict[str, Any]) -> Dict[str, Any]:
+    """Ensure lowercase hardware keys exist for their uppercase counterparts.
+
+    Some hardware records may come from sources that use uppercase keys (e.g.,
+    ``FLOPS`` instead of ``flops``). This helper preserves the original keys
+    while populating the expected lowercase versions when they are missing so
+    that API serializers can rely on a consistent shape.
+    """
+    if hardware is None:
+        return {}
+
+    normalized = dict(hardware)
+    for key, value in hardware.items():
+        if isinstance(key, str) and key.isupper():
+            lower_key = key.lower()
+            if lower_key not in normalized:
+                normalized[lower_key] = value
+    return normalized


### PR DESCRIPTION
## Summary
- add a shared helper to normalize hardware dictionaries and populate lowercase keys
- ensure FastAPI hardware routes format hardware records before serializing responses
- update the Flask hardware list route to return normalized hardware payloads as well

## Testing
- python -m compileall BudSimulator/apis/routers/hardware.py BudSimulator/src/api/hardware_routes.py BudSimulator/src/utils/hardware_formatting.py

------
https://chatgpt.com/codex/tasks/task_b_68daf0d798348326822297517c697e2a